### PR TITLE
Remove javax.transaction.xa

### DIFF
--- a/src/main/java/org/jboss/eapqe/jakarta/migration/process/JavaSourceFile.java
+++ b/src/main/java/org/jboss/eapqe/jakarta/migration/process/JavaSourceFile.java
@@ -122,7 +122,6 @@ public class JavaSourceFile {
         javaxPackages.put("javax.servlet.jsp.jstl.tlv.", "jakarta.servlet.jsp.jstl.tlv.");
         javaxPackages.put("javax.servlet.jsp.tagext.", "jakarta.servlet.jsp.tagext.");
         javaxPackages.put("javax.servlet.", "jakarta.servlet.");
-        javaxPackages.put("javax.transaction.xa.", "jakarta.transaction.xa.");
         javaxPackages.put("javax.transaction.", "jakarta.transaction.");
         javaxPackages.put("javax.validation.bootstrap.", "jakarta.validation.bootstrap.");
         javaxPackages.put("javax.validation.constraints.", "jakarta.validation.constraints.");

--- a/src/main/java/org/jboss/eapqe/jakarta/migration/process/PomFile.java
+++ b/src/main/java/org/jboss/eapqe/jakarta/migration/process/PomFile.java
@@ -212,7 +212,6 @@ public class PomFile {
             "javax.servlet.jsp.jstl.tlv",
             "javax.servlet.jsp.tagext",
             "javax.transaction",
-            "javax.transaction.xa",
             "javax.validation",
             "javax.validation.bootstrap",
             "javax.validation.constraints",


### PR DESCRIPTION
Now the `transaction.xa` is part of java SE and not included in jakarta. See README on https://github.com/jakartaee/transactions